### PR TITLE
Make canvas white; fake Earl Brown scores; set line width dynamically; fix bugs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
   </head>
   
-  <body onload="makeMondrianImg();">
+  <body onload="makeArtistImg('Brown');">
 
     <!-- fork me on github banner -->
     <a href="https://github.com/JEFworks/mondrian-generator">
@@ -21,7 +21,7 @@
       <canvas id="compositionCanvas" ></canvas>
       <script type="text/javascript" src="./mondrian-generator.js"></script>
       <br>
-      <button class="btn" onclick="clearCanvas(); makeMondrianImg();" href="javascript:void(0);">Generate New</button>
+      <button class="btn" onclick="clearCanvas(); makeArtistImg('Brown');" href="javascript:void(0);">Generate New</button>
       <a class='btn' id='save' onclick='saveCanvas()'  href="javascript:void(0);">Save Image</a>
     </center>
   </body>

--- a/index.html
+++ b/index.html
@@ -2,56 +2,19 @@
 <html>
 
   <head>
-    <style>
-      html {
-      font-family: sans-serif;
-      -webkit-text-size-adjust: 100%;
-      -ms-text-size-adjust: 100%;
-      }
-
-      body {
-      margin: 0;
-      }
-
-      .btn {
-      display: inline-block;
-      padding: 6px 12px;
-      margin-bottom: 0;
-      font-size: 14px;
-      font-weight: normal;
-      line-height: 1.42857143;
-      text-align: center;
-      white-space: nowrap;
-      vertical-align: middle;
-      -ms-touch-action: manipulation;
-      touch-action: manipulation;
-      cursor: pointer;
-      -webkit-user-select: none;
-      -moz-user-select: none;
-      -ms-user-select: none;
-      user-select: none;
-      background-image: none;
-      border: 1px solid transparent;
-      color: white;
-      text-decoration: none;
-      background-color: #aa0000;
-      margin: 18px 9px;
-      -o-border-radius: 7px;
-      -webkit-border-radius: 7px;
-      -moz-border-radius: 7px;
-      border-radius: 7px;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, .35);
-      -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, .35);
-      -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, .35);
-      -o-box-shadow: 0 1px 3px rgba(0, 0, 0, .35);
-      }
-    </style>
+    <link 
+      rel = "stylesheet"
+      type = "text/css"
+      href = "./stylesheet.css" 
+    />
   </head>
   
   <body onload="makeMondrianImg();">
 
     <!-- fork me on github banner -->
-    <a href="https://github.com/JEFworks/mondrian-generator"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
+    <a href="https://github.com/JEFworks/mondrian-generator">
+      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
+    </a>
     
     <center>
       <h1>Random Composition in Red, Blue, and Yellow</h1>      

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
   </head>
   
-  <body onload="makeArtistImg('Mondrian');">
+  <body onload="makeArtistImg('Mondrian', true, {variations: 1});">
 
     <!-- fork me on github banner -->
     <a href="https://github.com/JEFworks/mondrian-generator">
@@ -19,9 +19,12 @@
     <center>
       <h1>Random Composition in Red, Blue, and Yellow</h1>      
       <canvas id="compositionCanvas" ></canvas>
+      <!-- <canvas id="compositionCanvas2" ></canvas> -->
+      <!-- <canvas id="compositionCanvas3" ></canvas> -->
+
       <script type="text/javascript" src="./mondrian-generator.js"></script>
       <br>
-      <button class="btn" onclick="clearCanvas(); makeArtistImg('Mondrian');" href="javascript:void(0);">Generate New</button>
+      <button class="btn" onclick="clearCanvas(); makeArtistImg('Mondrian', true, {variations: 1});" href="javascript:void(0);">Generate New</button>
       <a class='btn' id='save' onclick='saveCanvas()'  href="javascript:void(0);">Save Image</a>
     </center>
   </body>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
   </head>
   
-  <body onload="makeArtistImg('Mondrian', true, {variations: 1});">
+  <body onload="makeArtistImg('LeWitt', false, {variations: 2});">
 
     <!-- fork me on github banner -->
     <a href="https://github.com/JEFworks/mondrian-generator">
@@ -24,7 +24,7 @@
 
       <script type="text/javascript" src="./mondrian-generator.js"></script>
       <br>
-      <button class="btn" onclick="clearCanvas(); makeArtistImg('Mondrian', true, {variations: 1});" href="javascript:void(0);">Generate New</button>
+      <button class="btn" onclick="clearCanvas(); makeArtistImg('LeWitt', false, {variations: 2});" href="javascript:void(0);">Generate New</button>
       <a class='btn' id='save' onclick='saveCanvas()'  href="javascript:void(0);">Save Image</a>
     </center>
   </body>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
   </head>
   
-  <body onload="makeArtistImg('LeWitt', false, {variations: 2});">
+  <body onload="makeArtistImg('Brown', true, {variations: 1});">
 
     <!-- fork me on github banner -->
     <a href="https://github.com/JEFworks/mondrian-generator">
@@ -24,7 +24,7 @@
 
       <script type="text/javascript" src="./mondrian-generator.js"></script>
       <br>
-      <button class="btn" onclick="clearCanvas(); makeArtistImg('LeWitt', false, {variations: 2});" href="javascript:void(0);">Generate New</button>
+      <button class="btn" onclick="clearCanvas(); makeArtistImg('Brown', true, {variations: 1});" href="javascript:void(0);">Generate New</button>
       <a class='btn' id='save' onclick='saveCanvas()'  href="javascript:void(0);">Save Image</a>
     </center>
   </body>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     
     <center>
       <h1>Random Composition in Red, Blue, and Yellow</h1>      
-      <canvas id="compositionCanvas" width="400" height="400"></canvas>
+      <canvas id="compositionCanvas" ></canvas>
       <script type="text/javascript" src="./mondrian-generator.js"></script>
       <br>
       <button class="btn" onclick="clearCanvas(); makeMondrianImg();" href="javascript:void(0);">Generate New</button>

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
 <body>
   <canvas 
     id="compositionCanvas" 
-    width=400 
-    height=400
   />
   <script src="./mondrian-generator.js"/></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     />
   </head>
   
-  <body onload="makeArtistImg('Brown');">
+  <body onload="makeArtistImg('Mondrian');">
 
     <!-- fork me on github banner -->
     <a href="https://github.com/JEFworks/mondrian-generator">
@@ -21,7 +21,7 @@
       <canvas id="compositionCanvas" ></canvas>
       <script type="text/javascript" src="./mondrian-generator.js"></script>
       <br>
-      <button class="btn" onclick="clearCanvas(); makeArtistImg('Brown');" href="javascript:void(0);">Generate New</button>
+      <button class="btn" onclick="clearCanvas(); makeArtistImg('Mondrian');" href="javascript:void(0);">Generate New</button>
       <a class='btn' id='save' onclick='saveCanvas()'  href="javascript:void(0);">Save Image</a>
     </center>
   </body>

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -81,9 +81,8 @@ function getContext() {
 }
 
 function getLineWidths(linePositions) {
-  // const LINE_WIDTHS = [2, 4, 6, 8, 10]
-  const LINE_WIDTHS = [4]
-
+  const LINE_WIDTHS = [2, 4, 6, 8, 10]
+  // const LINE_WIDTHS = [4]
   const BORDER_WIDTH = 4
 
   const lineWidths = linePositions.map((_, idx) => {
@@ -126,7 +125,7 @@ function fillContextSquares(context, xLineStarts, yLineStarts) {
   const numColors = getRandomInt(3, 10);
 
   for (let c = 0; c < numColors; c++) {
-    const { X_START, Y_START, WIDTH, RECT_HEIGHT, RECT_WIDTH } = getRectDims(xLineStarts, yLineStarts)
+    const { X_START, Y_START, RECT_HEIGHT, RECT_WIDTH } = getRectDims(xLineStarts, yLineStarts)
     context.beginPath();
     context.rect(X_START, Y_START, RECT_WIDTH, RECT_HEIGHT);
     const randColor = colors[getRandomInt(0, colors.length)];

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -6,7 +6,7 @@ function clearCanvas() {
 function autoSaveImg(image) {
   const link = document.createElement('a');
   link.href = image;
-  link.download = 'new-mondrian.jpg';
+  link.download = 'new-artwork.jpg';
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
@@ -77,6 +77,8 @@ function getContext() {
   canvas.width = CANVAS_WIDTH
   canvas.height = CANVAS_HEIGHT
   const context = canvas.getContext('2d');
+  context.fillStyle = "white";
+  context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
   return { context, canvas }
 }
 

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -80,8 +80,7 @@ function getContext() {
   return { context, canvas }
 }
 
-function getLineWidths(linePositions) {
-  const LINE_WIDTHS = [2, 7, 12, 17]
+function getLineWidths(linePositions, LINE_WIDTHS) {
   const BORDER_WIDTH = 4
 
   const lineWidths = linePositions.map((_, idx) => {
@@ -92,10 +91,33 @@ function getLineWidths(linePositions) {
   return lineWidths
 }
 
-function addLinesToContext(context, linePositions, xOrY, lineWidths) {
+function getLinePoints(artistName) {
+  let linePoints
+
+  if (artistName === 'Mondrian') {
+    linePoints = {
+      xStart: 0,
+      yStart: 0,
+      xStop: CANVAS_HEIGHT,
+      yStop: CANVAS_WIDTH
+    }
+  } else if (artistName === 'Brown') {
+    linePoints = {
+      xStart: getRandomInt(10, 380),
+      xStop: getRandomInt(10, 380),
+      yStart: getRandomInt(10, 380),
+      yStop: getRandomInt(10, 380)
+    }
+  }
+
+  return linePoints
+}
+
+function addLinesToContext(context, linePositions, xOrY, lineWidths, artistName) {
   linePositions.forEach((linePosition, idx) => {
-    const moveToArgs = xOrY === 'x' ? [linePosition, 0] : [0, linePosition]
-    const lineToArgs = xOrY === 'x' ? [linePosition, CANVAS_HEIGHT] : [CANVAS_WIDTH, linePosition]
+    const { xStart, xStop, yStart, yStop } = getLinePoints(artistName)
+    const moveToArgs = xOrY === 'x' ? [linePosition, xStart] : [yStart, linePosition]
+    const lineToArgs = xOrY === 'x' ? [linePosition, xStop] : [yStop, linePosition]
 
     context.beginPath();
     context.moveTo(...moveToArgs);
@@ -137,23 +159,50 @@ function fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLin
   return context
 }
 
-function makeMondrianImg(shouldSave) {
-  const { xLineStarts, yLineStarts } = getLineStarts()
+const makeArtistImgFuncs = {
+  Mondrian: (artistName, shouldSave) => {
+    const { xLineStarts, yLineStarts } = getLineStarts()
 
-  let { context, canvas } = getContext()
-  const xLineWidths = getLineWidths(xLineStarts)
-  const yLineWidths = getLineWidths(yLineStarts)
+    let { context, canvas } = getContext()
 
-  context = fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLineWidths)
-  context = addLinesToContext(context, xLineStarts, 'x', xLineWidths)
-  context = addLinesToContext(context, yLineStarts, 'y', yLineWidths)
+    const lineWidths = [2, 7, 12, 17]
+    const xLineWidths = getLineWidths(xLineStarts, lineWidths)
+    const yLineWidths = getLineWidths(yLineStarts, lineWidths)
 
-  if (shouldSave) {
-    saveCanvas(canvas)
+    context = fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLineWidths)
+    context = addLinesToContext(context, xLineStarts, 'x', xLineWidths, 'Mondrian')
+    context = addLinesToContext(context, yLineStarts, 'y', yLineWidths, 'Mondrian')
+
+    if (shouldSave) {
+      saveCanvas(canvas)
+    }
+  },
+  Brown: (artistName, shouldSave) => {
+    const { xLineStarts, yLineStarts } = getLineStarts()
+
+    let { context, canvas } = getContext()
+    const lineWidths = [2, 7, 12, 17]
+
+    const xLineWidths = getLineWidths(xLineStarts, lineWidths)
+    const yLineWidths = getLineWidths(yLineStarts, lineWidths)
+    const xStop = getRandomInt(0, 400)
+    const yStop = getRandomInt(0, 400)
+
+    context = addLinesToContext(context, xLineStarts, 'x', xLineWidths, 'Brown')
+    context = addLinesToContext(context, yLineStarts, 'y', yLineWidths, 'Brown')
+
+    if (shouldSave) {
+      saveCanvas(canvas)
+    }
   }
+}
+
+function makeArtistImg(artistName, shouldSave) {
+  makeArtistImgFuncs[artistName](artistName, shouldSave)
 }
 
 // makeMondrianImg(true)
 
 // TO DO:
 // 1. Add options that create an img resembling Earle Brown's "December 1952" score.
+// 2. Fill transparent squares with white.

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -84,19 +84,23 @@ function getContext() {
 
 function getLineWidths(linePositions, LINE_WIDTHS) {
   const BORDER_WIDTH = 4
+  console.log('linePositions:', linePositions)
 
   const lineWidths = linePositions.map((_, idx) => {
-    const lineWidth = idx === 0 || idx === linePositions.length - 1 ? BORDER_WIDTH : LINE_WIDTHS[getRandomInt(0, LINE_WIDTHS.length - 1)]
+    const lineWidth = isBorder(linePositions, idx) ? BORDER_WIDTH : LINE_WIDTHS[getRandomInt(0, LINE_WIDTHS.length - 1)]
+    console.log(`${idx}: ${lineWidth}`)
     return lineWidth
   })
 
   return lineWidths
 }
 
-function getLinePoints(artistName) {
+const isBorder = (linePositions, idx) => idx === 0 || idx === linePositions.length - 1
+
+function getLinePoints(artistName, linePositions, idx) {
   let linePoints
 
-  if (artistName === 'Mondrian') {
+  if (artistName === 'Mondrian' || isBorder(linePositions, idx)) {
     linePoints = {
       xStart: 0,
       yStart: 0,
@@ -117,7 +121,7 @@ function getLinePoints(artistName) {
 
 function addLinesToContext(context, linePositions, xOrY, lineWidths, artistName) {
   linePositions.forEach((linePosition, idx) => {
-    const { xStart, xStop, yStart, yStop } = getLinePoints(artistName)
+    const { xStart, xStop, yStart, yStop } = getLinePoints(artistName, linePositions, idx)
     const moveToArgs = xOrY === 'x' ? [linePosition, xStart] : [yStart, linePosition]
     const lineToArgs = xOrY === 'x' ? [linePosition, xStop] : [yStop, linePosition]
 
@@ -187,11 +191,10 @@ const makeArtistImgFuncs = {
 
     const xLineWidths = getLineWidths(xLineStarts, lineWidths)
     const yLineWidths = getLineWidths(yLineStarts, lineWidths)
-    const xStop = getRandomInt(0, 400)
-    const yStop = getRandomInt(0, 400)
 
     context = addLinesToContext(context, xLineStarts, 'x', xLineWidths, 'Brown')
     context = addLinesToContext(context, yLineStarts, 'y', yLineWidths, 'Brown')
+    // const linesWithBorders = addBorders(innerLines)
 
     if (shouldSave) {
       saveCanvas(canvas)

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -1,3 +1,16 @@
+const CANVAS_WIDTH = 400
+const CANVAS_HEIGHT = 400
+
+function getContext(fillStyle = 'white') {
+  const canvas = document.getElementById('compositionCanvas');
+  canvas.width = CANVAS_WIDTH
+  canvas.height = CANVAS_HEIGHT
+  const context = canvas.getContext('2d');
+  context.fillStyle = fillStyle
+  context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  return { context, canvas }
+}
+
 function clearCanvas() {
   let { context, canvas } = getContext()
   context.clearRect(0, 0, canvas.width, canvas.height);
@@ -26,7 +39,8 @@ const colorToHexMap = {
   red: '#fe0000',
   yellow: '#ffff00',
   blue: '#0000fe',
-  black: '#000000'
+  black: '#000000',
+  tan: '#e7e0b8'
 }
 
 const colors = ['red', 'yellow', 'black', 'blue'];
@@ -65,19 +79,6 @@ function getLineStarts(xOrY) {
   const lineStarts = orientXYtoTopLeft(innerLines, xOrY)
 
   return lineStarts
-}
-
-const CANVAS_WIDTH = 400
-const CANVAS_HEIGHT = 400
-
-function getContext() {
-  const canvas = document.getElementById('compositionCanvas');
-  canvas.width = CANVAS_WIDTH
-  canvas.height = CANVAS_HEIGHT
-  const context = canvas.getContext('2d');
-  context.fillStyle = "white";
-  context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
-  return { context, canvas }
 }
 
 function getLineWidths(linePositions, LINE_WIDTHS) {
@@ -150,12 +151,8 @@ function fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLin
 
   for (let c = 0; c < numColors; c++) {
     const { X_START, Y_START, RECT_HEIGHT, RECT_WIDTH } = getRectDims(xLineStarts, yLineStarts, xLineWidths, yLineWidths)
-    context.beginPath();
-    context.rect(X_START, Y_START, RECT_WIDTH, RECT_HEIGHT);
     const randColor = colors[getRandomInt(0, colors.length - 1)];
-    context.fillStyle = colorToHexMap[randColor];
-    context.fill();
-    context.stroke();
+    context = drawRect(context, colorToHexMap[randColor], X_START, Y_START, RECT_WIDTH, RECT_HEIGHT)
   }
 
   return context
@@ -205,17 +202,63 @@ const makeArtistImgFuncs = {
     if (shouldSave) {
       saveCanvas(fileName)
     }
+  },
+  LeWitt: (artistName, shouldSave, opts, fileName, idx) => {
+    let { context, canvas } = getContext(colorToHexMap.tan)
+
+    context = drawRect(context, colorToHexMap.black, 20, 20, 360, 360)
+
+    for (let i = 0; i < 7; i++) {
+      if (idx !== 0 && Math.random() > .9) {
+        console.log('hit')
+        continue
+      }
+      const xStart = (i * 48) + 40
+      const yStart = 40
+      const width = 28
+      const height = 160
+      context = drawRect(context, colorToHexMap.tan, xStart, yStart, width, height)
+    }
+
+    for (let i = 0; i < 3; i++) {
+      if (idx !== 0 && Math.random() > .7) {
+        console.log('hit')
+        continue
+      }
+      const xStart = 40
+      const yStart = (i * 48) + 220
+      const width = 318
+      const height = 30
+      context = drawRect(context, colorToHexMap.tan, xStart, yStart, width, height)
+    }
+
+    if (shouldSave) {
+      saveCanvas(fileName)
+    }
   }
+}
+
+function drawRect(context, fillStyle, xStart, yStart, width, height) {
+  context.beginPath();
+  context.rect(xStart, yStart, width, height);
+  context.fillStyle = fillStyle
+  context.fill();
+  context.stroke();
+
+  return context
 }
 
 function makeArtistImg(artistName, shouldSave, opts) {
   for (let i = 0; i < opts.variations; i++) {
-    makeArtistImgFuncs[artistName](artistName, shouldSave, opts, `new-artwork-${i + 1}`)
+    makeArtistImgFuncs[artistName](artistName, shouldSave, opts, `new-artwork-${i + 1}`, i)
   }
 }
 
 // makeMondrianImg(true)
 
 // TO DO:
-// 1. Set up opts object for variations.
-// 2. Fix border width bug.
+// 1. Mock Sol LeWitt image.
+// -- express all dims in LeWitt func in terms of CANVAS_HEIGHT and CANVAS_WIDTH.
+// 2. Mock van Doesburg image.
+// 3. Make Brown's "4 Systems" (with prependicular-only lines.)
+// 4. Fix border width bug.

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -81,8 +81,7 @@ function getContext() {
 }
 
 function getLineWidths(linePositions) {
-  // const LINE_WIDTHS = [2, 4, 6, 8, 10]
-  const LINE_WIDTHS = [4]
+  const LINE_WIDTHS = [2, 7, 12, 17]
   const BORDER_WIDTH = 4
 
   const lineWidths = linePositions.map((_, idx) => {
@@ -119,9 +118,6 @@ function getRectDims(xLineStarts, yLineStarts, xLineWidths, yLineWidths) {
   const RECT_WIDTH = xLineStarts[xPtr + 1] - X_START
   const RECT_HEIGHT = yLineStarts[yPtr + 1] - Y_START
 
-  console.log('RECT_WIDTH:', RECT_WIDTH)
-  console.log('RECT_HEIGHT:', RECT_HEIGHT)
-
   return { X_START, Y_START, RECT_WIDTH, RECT_HEIGHT }
 }
 
@@ -148,9 +144,9 @@ function makeMondrianImg(shouldSave) {
   const xLineWidths = getLineWidths(xLineStarts)
   const yLineWidths = getLineWidths(yLineStarts)
 
+  context = fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLineWidths)
   context = addLinesToContext(context, xLineStarts, 'x', xLineWidths)
   context = addLinesToContext(context, yLineStarts, 'y', yLineWidths)
-  context = fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLineWidths)
 
   if (shouldSave) {
     saveCanvas(canvas)
@@ -160,5 +156,4 @@ function makeMondrianImg(shouldSave) {
 // makeMondrianImg(true)
 
 // TO DO:
-// 1. Generate line widths dynamically.
-// 2. Add options that create an img resembling Earle Brown's "December 1952" score.
+// 1. Add options that create an img resembling Earle Brown's "December 1952" score.

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -129,13 +129,6 @@ function makeMondrianImg(shouldSave) {
   }
 }
 
-<<<<<<< HEAD
-makeMondrianImg()
-
-// TO DO:
-// 1. Generate line widths dynamically.
-// 2. Prevent illegal Mondrian squares- ones that only go across half of canvas.
-=======
 //makeMondrianImg(true)
 
 
@@ -143,4 +136,3 @@ makeMondrianImg()
 // 1. Generate line widths dynamically.
 // 2. Dynamically set the canvas size so it's larger.
 // 3.
->>>>>>> c5ee8614efafd58de216767e7f68948374a40ab4

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -36,8 +36,8 @@ function getRandomInt(min, max) {
 }
 
 function orientXYtoTopLeft(xInnerLines, yInnerLines) {
-  const xLineStarts = xInnerLines.sort();
-  const yLineStarts = yInnerLines.sort().reverse();
+  const xLineStarts = xInnerLines.sort((a, b) => a - b);
+  const yLineStarts = yInnerLines.sort((a, b) => a - b).reverse();
 
   return { xLineStarts, yLineStarts }
 }
@@ -81,12 +81,12 @@ function getContext() {
 }
 
 function getLineWidths(linePositions) {
-  const LINE_WIDTHS = [2, 4, 6, 8, 10]
-  // const LINE_WIDTHS = [4]
+  // const LINE_WIDTHS = [2, 4, 6, 8, 10]
+  const LINE_WIDTHS = [4]
   const BORDER_WIDTH = 4
 
   const lineWidths = linePositions.map((_, idx) => {
-    const lineWidth = idx === 0 || idx === linePositions.length - 1 ? BORDER_WIDTH : LINE_WIDTHS[getRandomInt(0, LINE_WIDTHS.length)]
+    const lineWidth = idx === 0 || idx === linePositions.length - 1 ? BORDER_WIDTH : LINE_WIDTHS[getRandomInt(0, LINE_WIDTHS.length - 1)]
     return lineWidth
   })
 
@@ -110,25 +110,29 @@ function addLinesToContext(context, linePositions, xOrY, lineWidths) {
   return context
 }
 
-function getRectDims(xLineStarts, yLineStarts) {
-  const xPtr = getRandomInt(0, xLineStarts.length)
-  const yPtr = getRandomInt(0, yLineStarts.length)
+function getRectDims(xLineStarts, yLineStarts, xLineWidths, yLineWidths) {
+  const xPtr = getRandomInt(0, xLineStarts.length - 1)
+  const yPtr = getRandomInt(0, yLineStarts.length - 1)
+
   const X_START = xLineStarts[xPtr]
   const Y_START = yLineStarts[yPtr]
   const RECT_WIDTH = xLineStarts[xPtr + 1] - X_START
   const RECT_HEIGHT = yLineStarts[yPtr + 1] - Y_START
 
+  console.log('RECT_WIDTH:', RECT_WIDTH)
+  console.log('RECT_HEIGHT:', RECT_HEIGHT)
+
   return { X_START, Y_START, RECT_WIDTH, RECT_HEIGHT }
 }
 
-function fillContextSquares(context, xLineStarts, yLineStarts) {
+function fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLineWidths) {
   const numColors = getRandomInt(3, 10);
 
   for (let c = 0; c < numColors; c++) {
-    const { X_START, Y_START, RECT_HEIGHT, RECT_WIDTH } = getRectDims(xLineStarts, yLineStarts)
+    const { X_START, Y_START, RECT_HEIGHT, RECT_WIDTH } = getRectDims(xLineStarts, yLineStarts, xLineWidths, yLineWidths)
     context.beginPath();
     context.rect(X_START, Y_START, RECT_WIDTH, RECT_HEIGHT);
-    const randColor = colors[getRandomInt(0, colors.length)];
+    const randColor = colors[getRandomInt(0, colors.length - 1)];
     context.fillStyle = colorToHexMap[randColor];
     context.fill();
     context.stroke();
@@ -146,7 +150,7 @@ function makeMondrianImg(shouldSave) {
 
   context = addLinesToContext(context, xLineStarts, 'x', xLineWidths)
   context = addLinesToContext(context, yLineStarts, 'y', yLineWidths)
-  context = fillContextSquares(context, xLineStarts, yLineStarts)
+  context = fillContextSquares(context, xLineStarts, yLineStarts, xLineWidths, yLineWidths)
 
   if (shouldSave) {
     saveCanvas(canvas)

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -19,7 +19,7 @@ function clearCanvas() {
 function autoSaveImg(image, fileName) {
   const link = document.createElement('a');
   link.href = image;
-  link.download = `${fileName}.jpg`;
+  link.download = `${fileName}.png`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
@@ -97,7 +97,7 @@ const isBorder = (linePositions, idx) => idx === 0 || idx === linePositions.leng
 function getLinePoints(artistName, linePositions, idx) {
   let linePoints
 
-  if (artistName === 'Mondrian' || isBorder(linePositions, idx)) {
+  if (artistName === 'Mondrian') {
     linePoints = {
       xStart: 0,
       yStart: 0,
@@ -210,7 +210,6 @@ const makeArtistImgFuncs = {
 
     for (let i = 0; i < 7; i++) {
       if (idx !== 0 && Math.random() > .9) {
-        console.log('hit')
         continue
       }
       const xStart = (i * 48) + 40
@@ -262,3 +261,8 @@ function makeArtistImg(artistName, shouldSave, opts) {
 // 2. Mock van Doesburg image.
 // 3. Make Brown's "4 Systems" (with prependicular-only lines.)
 // 4. Fix border width bug.
+// 5. Create a demo of my vision for the video animations in FinalCut Pro.
+// --Re-do the .png word images in 4 new colors: black, yellow, red, and blue. -- DONE
+// --Create 1 demo with photographs, and 1 with mocked .pngs.
+// --If mocked .pngs are too boring, explore photo-manipulation software that
+// will make the photographs sharper. 

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -43,14 +43,17 @@ function orientXYtoTopLeft(xInnerLines, yInnerLines) {
 }
 
 function addBorders(innerLines) {
-  const linesWithBorders = [2, ...innerLines, 398]
+  const BORDER_WIDTH = 2
+  const linesWithBorders = [BORDER_WIDTH, ...innerLines, CANVAS_WIDTH - BORDER_WIDTH]
   return linesWithBorders
 }
 
 function getInnerLines(numLines) {
   const innerLines = [];
+  const PADDING_MARGIN = 10
+
   for (let i = 0; i < numLines; i++) {
-    innerLines.push(getRandomInt(10, 380))
+    innerLines.push(getRandomInt(PADDING_MARGIN, CANVAS_WIDTH - PADDING_MARGIN))
   };
   const linesWithBorders = addBorders(innerLines)
   return linesWithBorders
@@ -66,10 +69,13 @@ function getLineStarts() {
   return { xLineStarts, yLineStarts }
 }
 
+const CANVAS_WIDTH = 400
+const CANVAS_HEIGHT = 400
+
 function getContext() {
   const canvas = document.getElementById('compositionCanvas');
-  canvas.width = 400
-  canvas.height = 400
+  canvas.width = CANVAS_WIDTH
+  canvas.height = CANVAS_HEIGHT
   const context = canvas.getContext('2d');
   return { context, canvas }
 }
@@ -86,7 +92,7 @@ function addLinesToContext(context, linePositions, xOrY) {
   linePositions.forEach((linePosition, idx) => {
     const LINE_WIDTH = getLineWidth(idx, linePositions)
     const moveToArgs = xOrY === 'x' ? [linePosition, 0] : [0, linePosition]
-    const lineToArgs = xOrY === 'x' ? [linePosition, 400] : [400, linePosition]
+    const lineToArgs = xOrY === 'x' ? [linePosition, CANVAS_HEIGHT] : [CANVAS_WIDTH, linePosition]
 
     context.beginPath();
     context.moveTo(...moveToArgs);
@@ -102,6 +108,7 @@ function addLinesToContext(context, linePositions, xOrY) {
 
 function fillContextSquares(context, x, y) {
   const numColors = getRandomInt(3, 10);
+
   for (let c = 0; c < numColors; c++) {
     const xPtr = getRandomInt(0, x.length)
     const yPtr = getRandomInt(0, y.length)
@@ -129,10 +136,8 @@ function makeMondrianImg(shouldSave) {
   }
 }
 
-//makeMondrianImg(true)
-
+// makeMondrianImg(true)
 
 // TO DO:
 // 1. Generate line widths dynamically.
-// 2. Dynamically set the canvas size so it's larger.
-// 3.
+// 2. Modularize <style/> tag into .css file.

--- a/mondrian-generator.js
+++ b/mondrian-generator.js
@@ -204,7 +204,3 @@ function makeArtistImg(artistName, shouldSave) {
 }
 
 // makeMondrianImg(true)
-
-// TO DO:
-// 1. Add options that create an img resembling Earle Brown's "December 1952" score.
-// 2. Fill transparent squares with white.

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,42 @@
+html {
+  font-family: sans-serif;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+}
+
+.btn {
+  display: inline-block;
+  padding: 6px 12px;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1.42857143;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-image: none;
+  border: 1px solid transparent;
+  color: white;
+  text-decoration: none;
+  background-color: #aa0000;
+  margin: 18px 9px;
+  -o-border-radius: 7px;
+  -webkit-border-radius: 7px;
+  -moz-border-radius: 7px;
+  border-radius: 7px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  -o-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+}


### PR DESCRIPTION
More prep work in anticipating of extending script functionality to non-Mondrian works of art.

There are 3 types of changes in this P.R., maintainability changes, feature changes, and bug fixes:

**Feature Changes:**
- Make canvas background white, not transparent (while it appears white on index.html, that's only because it's the default styling; downloading the image will show weird, transparent spaces where there is no RYB color.)
- Generate .png files that imitate the work of artists besides Piet Mondrian, like Earle Brown and his aleatoric music scores (as in his work ["December 1952"](https://f4.bcbits.com/img/a3235846286_10.jpg))
- Make line widths differ dynamically (a major feature of Mondrian's work, previously absent from the abilities of this `mondrian-generator` repo.)

**Maintainability Changes:**
- Removed comments that are now redundant, in view of code changes (like var renames & func modularizations);
- Divided functions into smaller, more re-usable parts;
- Made var names more specific, particularly to underline the evolution of the canvas' drawn lines from internal points, to external points, and, finally, to 2-dimensional realizations.
- Modularize <style/> tag into its own external `.css` file.

**Bug Fixes:**
- Fixed bug in use of `.getRandomInt` that would generate erroneous indexes for arrays (was accidentally passing in `array.length`, not `array.length - 1`.)

**N.B.**: There is one outstanding bug — the code [here](https://github.com/JEFworks/mondrian-generator/pull/4/files#diff-8ceae1359932e72f009942baf0bcf5d4eb87356e5ceefee44c2baac79c2d0d15R142) will sometimes generate `undefined` values. If `xPtr` or `yPtr` is the last index in an array, then `xLineStarts[xPtr + 1]` will obviously not exist. However, this bug is not surfacing in the actual `.png` images themselves anywhere, so I'll leave it aside for now.